### PR TITLE
add WebSocket server stop process when onServerStopping called

### DIFF
--- a/src/main/java/com/github/takecx/remotecontrollermod/Remotecontrollermod.java
+++ b/src/main/java/com/github/takecx/remotecontrollermod/Remotecontrollermod.java
@@ -18,6 +18,7 @@ import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModEnqueueEvent;
 import net.minecraftforge.fml.event.lifecycle.InterModProcessEvent;
 import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.network.NetworkRegistry;
 import net.minecraftforge.fml.network.simple.SimpleChannel;
@@ -130,6 +131,14 @@ public class Remotecontrollermod {
 
             wsServer = new WSServer(new InetSocketAddress(host, port));
             wsServer.start();
+        }
+    }
+
+    @SubscribeEvent
+    public void onServerStopping(FMLServerStoppingEvent event) throws InterruptedException {
+        LOGGER.info("GOODBYE from server stopping");
+        if (!event.getServer().getWorld(World.OVERWORLD).isRemote) {
+            wsServer.stop();
         }
     }
 


### PR DESCRIPTION
# 概要
ワールドから抜けるときに、WebSocketインスタンスのstop処理を呼んでおらず、次回接続時に失敗してしまう問題を修正