### PR TITLE
fix range of setBlocks API

### DIFF
--- a/src/main/java/com/github/takecx/remotecontrollermod/APIHandler.java
+++ b/src/main/java/com/github/takecx/remotecontrollermod/APIHandler.java
@@ -197,9 +197,9 @@ public class APIHandler {
                 int endX = Integer.parseInt(arg_content[3]);
                 int endY = Integer.parseInt(arg_content[4]);
                 int endZ = Integer.parseInt(arg_content[5]);
-                for (int x = startX; x < endX; x++) {
-                    for (int y = startY; y < endY; y++) {
-                        for (int z = startZ; z < endZ; z++) {
+                for (int x = startX; x < endX + 1; x++) {
+                    for (int y = startY; y < endY + 1; y++) {
+                        for (int z = startZ; z < endZ + 1; z++) {
                             BlockPos targetPos = new BlockPos(x,y,z);
                             myWorld.setBlockState(targetPos, block.getDefaultState());
                         }

--- a/src/main/java/com/github/takecx/remotecontrollermod/APIHandler.java
+++ b/src/main/java/com/github/takecx/remotecontrollermod/APIHandler.java
@@ -197,6 +197,9 @@ public class APIHandler {
                 int endX = Integer.parseInt(arg_content[3]);
                 int endY = Integer.parseInt(arg_content[4]);
                 int endZ = Integer.parseInt(arg_content[5]);
+                if (startX > endX) {int tmp = startX; startX = endX; endX = tmp;}
+                if (startY > endY) {int tmp = startY; startY = endY; endY = tmp;}
+                if (startZ > endZ) {int tmp = startZ; startZ = endZ; endZ = tmp;}
                 for (int x = startX; x < endX + 1; x++) {
                     for (int y = startY; y < endY + 1; y++) {
                         for (int z = startZ; z < endZ + 1; z++) {


### PR DESCRIPTION
#18 
setBlocks APIが動かない時がある不具合を修正しました。

setBlocksでは、直方体だけでなく、平面、直線、点を描くことも想定されています。

x,y,zいずれかの座標指定が(0, 0, 0,  0, 2, 0)など開始点＝終了点のものを含んでいるとき、ループが終了していました。