### PR TITLE
set javac encoding to utf-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,9 @@
 apply plugin:'java'
 
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
 buildscript {
     repositories {
         maven { url = 'https://files.minecraftforge.net/maven' }


### PR DESCRIPTION
コンパイル時に日本語のコメント部分でエラーが出ていたので、エンコーディングを設定しました。
元のSpawnEntityMessageToClient関係のエラーは解消されており、できたjarファイルも正常に動作しました。